### PR TITLE
rollup: also suppress CIRCULAR_DEPENDENCY warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,12 +13,8 @@ const mode = process.env.NODE_ENV;
 const dev = mode === 'development';
 const legacy = !!process.env.SAPPER_LEGACY_BUILD;
 
-const onwarn = (warning, onwarn) =>
-  (warning.code === 'CIRCULAR_DEPENDENCY' &&
-    /[/\\]@sapper[/\\]/.test(warning.message)) ||
-  onwarn(warning);
-const dedupe = importee =>
-  importee === 'svelte' || importee.startsWith('svelte/');
+const onwarn = (warning, onwarn) => (warning.code === 'CIRCULAR_DEPENDENCY' && /[/\\]@sapper[/\\]/.test(warning.message)) || onwarn(warning);
+const dedupe = importee => importee === 'svelte' || importee.startsWith('svelte/');
 
 const purgecss = require('@fullhuman/postcss-purgecss')({
   // Specify the paths to all of the template files in your project
@@ -43,9 +39,9 @@ export default {
         emitCss: true
       }),
       resolve({
-        browser: true,
-        dedupe
-      }),
+				browser: true,
+				dedupe
+			}),
       commonjs(),
       json(),
 
@@ -109,8 +105,8 @@ export default {
         ].filter(Boolean)
       }),
       resolve({
-        dedupe
-      }),
+				dedupe
+			}),
       commonjs(),
       json()
     ],


### PR DESCRIPTION
to suppress CIRCULAR_DEPENDENCY warnings this fix is taken from  [07fc656](https://github.com/sveltejs/sapper-template/commit/07fc656bba0f1b999afd38334573bc3a9c0436ab) commit on sapper-template